### PR TITLE
Remove two random samples for hypothesis.

### DIFF
--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -4,6 +4,8 @@ from axelrod import Alternator, Cooperator, Defector, Match
 from axelrod.action import Action
 from ctypes import c_int, c_float, POINTER
 
+import itertools
+
 from hypothesis import given
 from hypothesis.strategies import integers
 
@@ -31,17 +33,15 @@ def test_matches():
 
 
 @given(
-    their_last_move=integers(min_value=0, max_value=1),
     move_number=integers(min_value=1, max_value=200),
     my_score=integers(min_value=0, max_value=200),
     their_score=integers(min_value=0, max_value=200),
-    my_last_move=integers(min_value=0, max_value=1))
-def test_original_strategy(
-    their_last_move, move_number, my_score, their_score, my_last_move
-):
-    for strategy in all_strategies:
-        player = Player(strategy)
-        action = player.original_strategy(
-            their_last_move, move_number, my_score, their_score, 0,
-            my_last_move)
-        assert action in (0, 1), print(f'{strategy} returned {action}')
+    )
+def test_original_strategy(move_number, my_score, their_score):
+    for their_last_move, my_last_move in itertools.product((0, 1), repeat=2):
+        for strategy in all_strategies:
+            player = Player(strategy)
+            action = player.original_strategy(
+                their_last_move, move_number, my_score, their_score, 0,
+                my_last_move)
+            assert action in (0, 1), print(f'{strategy} returned {action}')


### PR DESCRIPTION
hypothesis by default randomly samples 200 experiments, as 2 of our
variables have the option of 2 values this is wasted. I've removed them
from the `given` calls and just included the 4 cases in a loop.

FWIW, I've just run this with and it's passed 5 times in a row and then hypothesis found an actual failing case:

```
k48r returned -1
...
Falsifying example: test_original_strategy(move_number=159, my_score=0, their_score=0)
```

That indicates that k48r might do something strange or perhaps it plays in such a way that it knows that it's not possible that move number 159 results in a score pair of 0, 0? (For example perhaps it knows that someone would have defected by move number 159...)