### PR TITLE
Classify all strategies as stochastic.

### DIFF
--- a/src/axelrod_fortran/player.py
+++ b/src/axelrod_fortran/player.py
@@ -12,6 +12,8 @@ original_actions = {C: 0, D: 1}
 
 class Player(axl.Player):
 
+    classifier = {"stochastic": True}
+
     def __init__(self, original_name, game=Game()):
         """
         Parameters

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -12,6 +12,7 @@ C, D = Action.C, Action.D
 def test_init():
     for strategy in all_strategies:
         player = Player(strategy)
+        assert player.classifier["stochastic"]
         assert player.original_name == strategy
         assert player.original_function.argtypes == (
             POINTER(c_int), POINTER(c_int), POINTER(c_int), POINTER(c_int),


### PR DESCRIPTION
This isn't necessarily correct but it does ensure that the cache will
not be used in an axelrod.Match.